### PR TITLE
Add network meeting organizer script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# Network Meeting Organizer
+
+This repository contains a small Python utility to help manage network meetings.
+It keeps track of participants, who they have previously sat with, and can
+suggest a new table plan where participants meet new people.
+
+## Files
+
+- `network_manager.py` – core library and command line tool
+- `demo.py` – example usage with sample data
+
+## Usage
+
+```
+python demo.py
+```
+
+This will print a suggested table plan based on the sample meetings in
+`demo.py`.
+
+You can also use `network_manager.py` directly:
+
+```
+python network_manager.py generate_plan 3
+```
+
+See `--help` for more commands.

--- a/demo.py
+++ b/demo.py
@@ -1,0 +1,26 @@
+import json
+from network_manager import Network
+
+network = Network()
+
+# Example participants
+participants = ["Alice", "Bob", "Charlie", "Diana", "Erik", "Frida", "Gustav", "Hanne"]
+for p in participants:
+    network.add_participant(p)
+
+# Example meeting history
+network.add_meeting({
+    "Bord 1": ["Alice", "Bob", "Charlie"],
+    "Bord 2": ["Diana", "Erik", "Frida"],
+    "Bord 3": ["Gustav", "Hanne"]
+})
+
+network.add_meeting({
+    "Bord 1": ["Alice", "Diana", "Gustav"],
+    "Bord 2": ["Bob", "Erik", "Hanne"],
+    "Bord 3": ["Charlie", "Frida"]
+})
+
+# Generate a plan for next meeting with tables of size 3
+plan = network.generate_table_plan(3)
+print(json.dumps(plan, indent=2, ensure_ascii=False))

--- a/network_manager.py
+++ b/network_manager.py
@@ -1,0 +1,79 @@
+from dataclasses import dataclass, field
+from itertools import combinations
+import random
+from typing import Dict, List, Set, Tuple
+
+@dataclass
+class Network:
+    participants: Set[str] = field(default_factory=set)
+    meetings: List[Dict[str, List[str]]] = field(default_factory=list)
+    pair_counts: Dict[frozenset, int] = field(default_factory=dict)
+
+    def add_participant(self, name: str) -> None:
+        self.participants.add(name)
+
+    def add_meeting(self, table_assignments: Dict[str, List[str]]) -> None:
+        """Add meeting table assignments and update pair counts."""
+        for table, names in table_assignments.items():
+            for name in names:
+                self.add_participant(name)
+            for pair in combinations(names, 2):
+                key = frozenset(pair)
+                self.pair_counts[key] = self.pair_counts.get(key, 0) + 1
+        self.meetings.append(table_assignments)
+
+    def generate_table_plan(self, table_size: int) -> Dict[str, List[str]]:
+        """Generate a new table plan with minimal repeated pairs."""
+        if not self.participants:
+            return {}
+        participants = list(self.participants)
+        random.shuffle(participants)
+        tables: List[List[str]] = []
+        for name in participants:
+            best_table = None
+            best_score = None
+            for table in tables:
+                if len(table) >= table_size:
+                    continue
+                score = sum(self.pair_counts.get(frozenset([name, p]), 0) for p in table)
+                if best_score is None or score < best_score:
+                    best_table = table
+                    best_score = score
+            if best_table is None:
+                best_table = []
+                tables.append(best_table)
+            best_table.append(name)
+        return {f"Table {i+1}": names for i, names in enumerate(tables)}
+
+if __name__ == "__main__":
+    import json
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Manage network meetings")
+    subparsers = parser.add_subparsers(dest="command")
+
+    add_part = subparsers.add_parser("add_participant")
+    add_part.add_argument("name")
+
+    add_meet = subparsers.add_parser("add_meeting")
+    add_meet.add_argument("file", help="JSON file with table assignments")
+
+    gen_plan = subparsers.add_parser("generate_plan")
+    gen_plan.add_argument("table_size", type=int)
+
+    args = parser.parse_args()
+    network = Network()
+
+    if args.command == "add_participant":
+        network.add_participant(args.name)
+        print(f"Added participant {args.name}")
+    elif args.command == "add_meeting":
+        with open(args.file) as f:
+            data = json.load(f)
+        network.add_meeting(data)
+        print("Meeting added")
+    elif args.command == "generate_plan":
+        plan = network.generate_table_plan(args.table_size)
+        print(json.dumps(plan, indent=2, ensure_ascii=False))
+    else:
+        parser.print_help()


### PR DESCRIPTION
## Summary
- add a small utility to keep track of network meeting tables
- show example usage in `demo.py`
- document how to run the scripts in README

## Testing
- `python demo.py`
- `python network_manager.py generate_plan 3`

------
https://chatgpt.com/codex/tasks/task_b_6842b276c8d8832fbb1ba214e39cf220